### PR TITLE
Add support for dynamic modification of content in install_services_cp

### DIFF
--- a/hammer/__init__.py
+++ b/hammer/__init__.py
@@ -1,6 +1,6 @@
 hammer_name = 'tg-hammer'
 hammer_description = 'Helpers for fabric based deployments.'
-hammer_version = '0.6.2'
+hammer_version = '0.6.3'
 
 __name__ = hammer_name
 __description__ = hammer_description


### PR DESCRIPTION
Adds optional third element `transform` to service tuples.
This new element is a function w/ signature:

```
(target_name, remote_file_data) -> (target_name, remote_file_data)
```

which can be used for dynamic service configuration generation