### PR TITLE
[service_helpers] Allow to override daemon_type and daemon_target dir

### DIFF
--- a/hammer/__init__.py
+++ b/hammer/__init__.py
@@ -1,6 +1,6 @@
 hammer_name = 'tg-hammer'
 hammer_description = 'Helpers for fabric based deployments.'
-hammer_version = '0.6.3'
+hammer_version = '0.6.4'
 
 __name__ = hammer_name
 __description__ = hammer_description

--- a/hammer/service_helpers.py
+++ b/hammer/service_helpers.py
@@ -26,37 +26,38 @@ DAEMON_TYPES = {
 }
 
 
-def get_service_daemon():
+def get_service_daemon(daemon_type=None, daemon_target_dir=None):
     require('service_daemon')
 
-    if env.service_daemon not in DAEMON_TYPES:
-        abort('Provided `service_daemon` %s is invalid. Supported daemon types are: %s' % (env.service_daemon, ', '.join(DAEMON_TYPES)))
+    daemon_type = daemon_type or env.service_daemon
 
-    daemon_conf = copy(DAEMON_TYPES[env.service_daemon])
+    if daemon_type not in DAEMON_TYPES:
+        abort('Provided `service_daemon` %s is invalid. Supported daemon types are: %s' % (daemon_type, ', '.join(DAEMON_TYPES)))
+
+    daemon_conf = copy(DAEMON_TYPES[daemon_type])
 
     # Support loading target_dir from env
-    daemon_conf['target_dir'] = getattr(env, 'service_daemon_target_dir', daemon_conf['target_dir'])
+    daemon_conf['target_dir'] = daemon_target_dir or getattr(env, 'service_daemon_target_dir', daemon_conf['target_dir'])
 
     if not daemon_conf['target_dir']:
         abort('`env.service_daemon_target_dir` must not be empty')
 
-    return env.service_daemon, daemon_conf
+    return daemon_type, daemon_conf
 
 
-def install_services(services):
+def install_services(services, daemon_type=None, daemon_target_dir=None):
     """Install provided services by uploading configuration files to the detected ``daemon_type`` specific directory
 
     :param services: List of services to install where each item is a tuple with the signature: ``(target_name, file_data)``
-
-    **Note:**
-        One can overwrite the default target dir via ``env.service_daemon_target_dir``
+    :param daemon_type: Can be used to override ``env.service_daemon`` value
+    :param daemon_target_dir: Can be used to override ``env.service_daemon_target_dir`` value
 
     **Warning:**
         For supervisor the default include dir is `/etc/supervisord/conf.d/`, this directory must be included
         in the global supervisor configuration.
     """
 
-    daemon_type, daemon_conf = get_service_daemon()
+    daemon_type, daemon_conf = get_service_daemon(daemon_type=daemon_type, daemon_target_dir=daemon_target_dir)
 
     for target_name, file_data in services:
         target_path = os.path.join(daemon_conf['target_dir'], '%s.%s' % (target_name, daemon_conf['file_extension']))
@@ -65,22 +66,24 @@ def install_services(services):
 
     if daemon_type == 'supervisor':
         # Ensure configuration files are reloaded
-        manage_service('supervisorctl', 'reread')
-        manage_service('supervisorctl', 'update')
+        manage_service('', 'reread', daemon_type=daemon_type)
+        manage_service('', 'update', daemon_type=daemon_type)
 
     elif daemon_type == 'systemd':
         # Ensure configuration files are reloaded
-        manage_service('', 'daemon-reload')
+        manage_service('', 'daemon-reload', daemon_type=daemon_type)
 
         # Ensure services are started on startup
-        manage_service([target_name for target_name, file_data in services], 'enable')
+        manage_service([target_name for target_name, file_data in services], 'enable', daemon_type=daemon_type)
 
 
-def install_services_cp(services):
+def install_services_cp(services, daemon_type=None, daemon_target_dir=None):
     """Install provided services by copying the remote file to the detected ``daemon_type`` specific directory
 
     :param services: List of services to install where each item is a tuple with the signature:
         ``(target_name, remote_file_path[, transform])``
+    :param daemon_type: Can be used to override ``env.service_daemon`` value
+    :param daemon_target_dir: Can be used to override ``env.service_daemon_target_dir`` value
 
     The remote_file_path supports the following keywords:
 
@@ -90,16 +93,13 @@ def install_services_cp(services):
     `transform` is an optional function w/ signature `(target_name, remote_file_data) -> (target_name, remote_file_data)` which
       can be used for dynamic service configuration
 
-    **Note:**
-        One can overwrite the default target dir via ``env.service_daemon_target_dir``
-
     **Warning:**
         For supervisor the default include dir is `/etc/supervisord/conf.d/`, this directory must be included
         in the global supervisor configuration.
     """
 
     prepared_services = []
-    daemon_type, daemon_conf = get_service_daemon()
+    daemon_type, daemon_conf = get_service_daemon(daemon_type=daemon_type, daemon_target_dir=daemon_target_dir)
 
     for parts in services:
         if len(parts) == 3:
@@ -126,21 +126,22 @@ def install_services_cp(services):
         prepared_services.append(the_item)
 
     # Use standard install_services to install them
-    return install_services(prepared_services)
+    return install_services(prepared_services, daemon_type=daemon_type, daemon_target_dir=daemon_target_dir)
 
 
-def manage_service(names, action, raise_errors=True):
+def manage_service(names, action, raise_errors=True, daemon_type=None):
     """Perform `action` on services
 
     :param names: Can be a list of services or a name of a single service to control
     :param action: Action that should be executed for the given services
     :param raise_errors: A way to control if errors generated by command should be captured by fabric or not. By default
     it is set to raise errors
+    :param daemon_type: Can be used to override env.service_daemon value
     """
     if not isinstance(names, (list, tuple)):
         names = [names, ]
 
-    daemon_type, daemon_conf = get_service_daemon()
+    daemon_type, daemon_conf = get_service_daemon(daemon_type=daemon_type)
 
     for name in names:
         full_cmd = daemon_conf['daemon_cmd'] % {

--- a/hammer/vcs/hg.py
+++ b/hammer/vcs/hg.py
@@ -68,7 +68,7 @@ class Mercurial(BaseVcs):
 
     def get_revset_log(self, revs):
         with cd(self.code_dir):
-            result = self.remote_cmd("hg --config ui.color=never log --pager=off --template '{rev}:{node|short} {branch} "
+            result = self.remote_cmd("hg --config ui.color=never --config ui.paginate=never log --template '{rev}:{node|short} {branch} "
                                      "{author} {desc|firstline}\\n' -r '%s'" % revs)
 
             if not result:
@@ -104,7 +104,8 @@ class Mercurial(BaseVcs):
 
     def _changed_files(self, revision_set):
         with cd(self.code_dir):
-            result = self.remote_cmd("hg --config ui.color=never --pager=off status --rev '%s'" % revision_set, quiet=True).splitlines()
+            result = self.remote_cmd("hg --config ui.color=never --config ui.paginate=never status --rev '%s'" % revision_set,
+                                     quiet=True).splitlines()
 
             return result
 


### PR DESCRIPTION
- install_services
- install_services_cp
- manage_service
- Fix a bug w/ supervisor update & reread which caused the actual command
  that was executed to be `supervisorctl <action> supervisorctl`