### PR TITLE
Make setup.py pip 10 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@ import uuid
 
 import hammer
 
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 try:
     from setuptools import setup


### PR DESCRIPTION
Currently, tg-hammer won't install with pip>=10