### PR TITLE
Feature/fix git branch name detection

### DIFF
--- a/hammer/vcs/base.py
+++ b/hammer/vcs/base.py
@@ -1,4 +1,5 @@
 import re
+import ftfy
 
 from fabric.api import sudo, run, env, hide
 
@@ -106,12 +107,16 @@ class BaseVcs(object):
         else:
             return self._remote_cmd(*args, **kwargs)
 
+    @classmethod
+    def cleanup_command_result(cls, result):
+        return ftfy.fix_text(ftfy.guess_bytes(result)[0])
+
     def _remote_cmd(self, *args, **kwargs):
         if not self.use_sudo:  # pragma: no cover
-            return run(*args, **kwargs)
+            return self.cleanup_command_result(run(*args, **kwargs))
 
         else:
-            return sudo(*args, **kwargs)  # pragma: no cover
+            return self.cleanup_command_result(sudo(*args, **kwargs))  # pragma: no cover
 
     def _changed_files(self, revision_set):
         raise NotImplementedError  # pragma: no cover

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 fabric>=1.10.2,<2
+ftfy==4.4.3
 
 # Backport of python3 ipaddress module
 py2-ipaddress>=3.4.1,<4

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,6 +6,7 @@ pytest==3.3.2
 coverage
 coveralls
 pytest-flake8==0.9.1
+flake8==3.6.0
 mock>=1.0.1
 tox>=1.7.0
 


### PR DESCRIPTION
In some versions of `git`, control characters were returned from `git branch` even if ran with '--color=never' option. Those characters were interpreted as part of branch name. This, in turn, caused failure in determining which branch was deployed (since no name matched), and no operation preformed on `fab server_name deploy` without specifying `id=...`

Three possible fixes were considered: using different git command, using a regex or using a package to clean & normalize the command output. Regex was turning overly complicated. A more reliable `for-each-ref` command was used, and a package for cleaning up command output was also added.

As additional benefit, it is now possible to correctly handle branch names with unicode characters (though hopefully no one uses unicode in branch names still).